### PR TITLE
Update disnake to 2.5.0, add vscode config files and loader environment variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,5 @@ logs/
 env/
 *.iml
 ffmpeg.exe
-.vscode/
 *.env
 db/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,24 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Compose: Launch and Debug",
+            "type": "python",
+            "preLaunchTask": "Compose Up",
+            "postDebugTask": "Compose Down",
+            "request": "attach",
+            "connect": {
+                "host": "localhost",
+                "port": 5678
+            },
+            "pathMappings": [
+                {
+                    "localRoot": "${workspaceFolder}",
+                    "remoteRoot": "."
+                }
+            ],
+            "justMyCode": false,
+            "internalConsoleOptions": "openOnSessionStart"
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "python.formatting.blackPath": "blue",
+    "python.formatting.provider": "black",
+    "editor.formatOnSave": true
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,7 +4,6 @@
         {
             "label": "Compose Up",
             "type": "docker-compose",
-            "isBackground": true,
             "dockerCompose": {
                 "up": {
                     "detached": true,

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,35 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Compose Up",
+            "type": "docker-compose",
+            "isBackground": true,
+            "dockerCompose": {
+                "up": {
+                    "detached": true,
+                    "build": true
+                },
+                "files": [
+                    "${workspaceFolder}/docker-compose.debug.yml"
+                ]
+            }
+        },
+        {
+            "label": "Compose Down",
+            "type": "docker-compose",
+            "isBackground": true,
+            "dockerCompose": {
+                "down": {
+                    "removeVolumes": true
+                },
+                "files": [
+                    "${workspaceFolder}/docker-compose.debug.yml"
+                ]
+            },
+            "presentation": {
+                "close": true
+            }
+        },
+    ]
+}

--- a/cogs/core/core.py
+++ b/cogs/core/core.py
@@ -402,7 +402,7 @@ class Core(commands.Cog):
             pass
 
     @commands.group(name='set', invoke_without_command=True)
-    @checks.admin_or_permissions(manage_guild=True)
+    @checks.is_owner()
     async def set_cmd(self, ctx):
         """Sets {}'s settings."""
         await self.heleus.send_command_help(ctx)
@@ -450,110 +450,6 @@ class Core(commands.Cog):
             await ctx.send('Owner set.')
         else:
             await ctx.send('Owners set.')
-
-    @set_cmd.command()
-    @commands.guild_only()
-    @checks.admin_or_permissions(manage_guild=True)
-    async def admin(self, ctx, *, role: discord.Role = None):
-        """Sets {}'s admin role.
-        Roles are case sensitive.
-
-        - role: The role to use as the admin role
-        """
-        roles = await self._get_guild_setting(ctx.guild.id, 'roles', {})
-        if role is not None:
-            roles['admin'] = role.id
-            await ctx.send(f'Admin role set to `{role.name}` successfully.')
-        else:
-            if 'admin' in roles:
-                roles.pop('admin')
-            await ctx.send(
-                'Admin role cleared.\n'
-                f"If you didn't intend to do this, use `{ctx.prefix}help set admin` for help."
-            )
-        await self._set_guild_setting(ctx.guild.id, 'roles', roles)
-
-    @set_cmd.command()
-    @commands.guild_only()
-    @checks.admin_or_permissions(manage_guild=True)
-    async def moderator(self, ctx, *, role: discord.Role = None):
-        """Sets {}'s moderator role.
-        Roles are case sensitive.
-
-        - role: The role to use as the moderator role
-        """
-        roles = await self._get_guild_setting(ctx.guild.id, 'roles', {})
-        if role is not None:
-            roles['mod'] = role.id
-            await ctx.send(f'Moderator role set to `{role}` successfully.')
-        else:
-            if 'mod' in roles:
-                roles.pop('mod')
-            await ctx.send(
-                'Moderator role cleared.\n'
-                f"If you didn't intend to do this, use `{ctx.prefix}help set moderator` for help."
-            )
-        await self._set_guild_setting(ctx.guild.id, 'roles', roles)
-
-    @set_cmd.group(name='ignore', invoke_without_command=True)
-    @checks.admin_or_permissions(manage_guild=True)
-    @commands.guild_only()
-    async def ignore_cmd(self, ctx):
-        """Helps you ignore/unignore servers/channels."""
-        await self.heleus.send_command_help(ctx)
-
-    @ignore_cmd.command()
-    @checks.admin_or_permissions(manage_guild=True)
-    @commands.guild_only()
-    async def channel(self, ctx, state: bool):
-        """Ignores/unignores the current channel.
-
-        - state: Whether or not to ignore the current channel
-        """
-        ignores = await self._get_guild_setting(ctx.guild.id, 'ignores', [])
-        channel = ctx.channel.id
-
-        if state:
-            if channel not in ignores:
-                ignores.append(channel)
-            await ctx.send('Channel ignored.')
-        else:
-            if channel in ignores:
-                ignores.remove(channel)
-            await ctx.send('Channel unignored.')
-        await self._set_guild_setting(ctx.guild.id, 'ignores', ignores)
-
-    @ignore_cmd.command()
-    @checks.admin_or_permissions(manage_guild=True)
-    @commands.guild_only()
-    async def server(self, ctx, state: bool):
-        """Ignores/unignores the current server.
-
-        - state: Whether or not to ignore the current server
-        """
-        if not self.heleus.intents.guilds:
-            return await self.ctx.send(
-                'Cannot ignore servers without the `guilds` intent.'
-            )
-        ignores = await self._get_guild_setting(ctx.guild.id, 'ignores', [])
-        guild = ctx.guild.id
-
-        if state:
-            if guild not in ignores:
-                ignores.append(guild)
-            await ctx.send('Server ignored.')
-        else:
-            if guild in ignores:
-                ignores.remove(guild)
-            await ctx.send('Server unignored.')
-        await self._set_guild_setting(ctx.guild.id, 'ignores', ignores)
-
-    async def halt_(self):
-        self.ignore_db = True
-        for cog in list(self.heleus.extensions):
-            self.heleus.unload_extension(cog)
-        await asyncio.sleep(2)  # to let some functions clean up their mess
-        await self.heleus.close()
 
     @commands.command(aliases=['shutdown'])
     @checks.is_owner()

--- a/cogs/core/core.py
+++ b/cogs/core/core.py
@@ -1,7 +1,5 @@
-import asyncio
 import datetime
 import inspect
-import random
 import textwrap
 import time
 import traceback

--- a/cogs/core/core.py
+++ b/cogs/core/core.py
@@ -140,30 +140,6 @@ class Core(commands.Cog):
             instance['mode'] = CoreMode.up
             await self.settings.set(self.heleus.instance_id, instance)
 
-        # migration
-        keys = await self.settings.keys()
-        if 'roles' in keys:
-            roles = await self.settings.get('roles')
-            for guild in roles:
-                await self._set_guild_setting(
-                    int(guild),
-                    'roles',
-                    {k.rstrip('_role'): v for k, v in roles[guild].items()},
-                )
-            await self.settings.delete('roles')
-        if 'ignores' in keys:
-            ignores = await self.settings.get('ignores')
-            for guild in ignores:
-                entry = []
-                [
-                    entry.append(int(x))
-                    for x in ignores[guild]['ignored_channels']
-                ]
-                if ignores[guild]['server_ignore']:
-                    entry.append(int(guild))
-                await self._set_guild_setting(int(guild), 'ignores', entry)
-            await self.settings.delete('ignores')
-
         # start the loops
         self._maintenance_loop.start()
         self._owner_checks.start()

--- a/docker-compose.debug.yml
+++ b/docker-compose.debug.yml
@@ -1,0 +1,32 @@
+version: '3'
+
+services:
+  redis:
+    image: redis:alpine
+    command: redis-server --appendonly yes
+    restart: always
+    networks:
+      - internal
+    volumes:
+      - ./db:/data
+
+  bot:
+    build: '.'
+    restart: always
+    depends_on:
+      - redis
+    networks:
+      - internal
+    env_file:
+      - .env
+    command:
+      [
+        "sh",
+        "-c",
+        "pip install debugpy -t /tmp && python /tmp/debugpy --wait-for-client --listen 0.0.0.0:5678 heleus.py --uvloop"
+      ]
+    ports:
+      - 5678:5678
+
+networks:
+  internal:

--- a/heleus.py
+++ b/heleus.py
@@ -271,8 +271,8 @@ if __name__ == '__main__':
     # Get defaults for argparse
     help_description = os.environ.get(
         'HELEUS_HELP',
-        'Heleus, an open-source Discord bot maintained by DerpyChap, '
-        'forked from Liara by Pandentia and contributors\n'
+        'Heleus, an open-source Discord bot base maintained by DerpyChap, '
+        'forked from Liara by Cassandra and contributors\n'
         'https://github.com/nerdcubed/Heleus',
     )
     runtime_name = os.environ.get('HELEUS_NAME', 'Heleus')

--- a/heleus.py
+++ b/heleus.py
@@ -320,7 +320,7 @@ if __name__ == '__main__':
 
     test_guilds = os.environ.get('HELEUS_TEST_GUILDS', None)
 
-    loader = os.environ.get('HELEUS_LOADER', None)
+    loader = os.environ.get('HELEUS_LOADER', 'cogs.core')
 
     # Parse command-line arguments
     parser = argparse.ArgumentParser()

--- a/heleus.py
+++ b/heleus.py
@@ -73,6 +73,7 @@ def create_bot(auto_shard: bool):
                 self.autoload = load_cogs.split(',')
             else:
                 self.autoload = None
+            self.loader = kwargs.pop('loader', 'cogs.core')
             super().__init__(*args, **kwargs)
 
             self.ready = False  # we expect the loader to set this once ready
@@ -85,11 +86,10 @@ def create_bot(auto_shard: bool):
 
             # load the core cog
             default = 'cogs.core'
-            loader = await self.settings.get('loader', default)
-            self.load_extension(loader)
+            self.load_extension(self.loader)
             if loader != default:
                 self.logger.warning(
-                    f'Using third-party loader and core cog, {loader}.'
+                    f'Using third-party loader and core cog, {loader}. No support will be provided if anything goes wrong!'
                 )
 
         def _process_pubsub_event(self, event):
@@ -320,6 +320,8 @@ if __name__ == '__main__':
 
     test_guilds = os.environ.get('HELEUS_TEST_GUILDS', None)
 
+    loader = os.environ.get('HELEUS_LOADER', None)
+
     # Parse command-line arguments
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -541,6 +543,7 @@ if __name__ == '__main__':
         cargs=cargs,
         test=cargs.test,
         name=cargs.name,
+        loader=loader,
     )  # heleus-specific args
 
     async def run_bot():

--- a/poetry.lock
+++ b/poetry.lock
@@ -100,7 +100,7 @@ graph = ["objgraph (>=1.7.2)"]
 
 [[package]]
 name = "disnake"
-version = "2.4.0"
+version = "2.5.0"
 description = "A Python wrapper for the Discord API"
 category = "main"
 optional = false
@@ -264,7 +264,7 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.10"
-content-hash = "a3b4a29641bf705c011a7c04bba8013ff2ca3bc6619d7d99bcc700475f7cf450"
+content-hash = "84f4da379d405391917737fe2e7234d29aadb01272df17ff6771222630c54b40"
 
 [metadata.files]
 aiohttp = [
@@ -417,8 +417,8 @@ dill = [
     {file = "dill-0.3.4.zip", hash = "sha256:9f9734205146b2b353ab3fec9af0070237b6ddae78452af83d2fca84d739e675"},
 ]
 disnake = [
-    {file = "disnake-2.4.0-py3-none-any.whl", hash = "sha256:390250a55ed8bbcc8c5753a72fb8fff2376a30295476edfebd0d2301855fb919"},
-    {file = "disnake-2.4.0.tar.gz", hash = "sha256:d7a9c83d5cbfcec42441dae1d96744f82c2a22403934db5d8862a8279ca4989c"},
+    {file = "disnake-2.5.0-py3-none-any.whl", hash = "sha256:8f64bfda301d4113bc05d2728448b87711e9d962d4428741c55b3018372c4753"},
+    {file = "disnake-2.5.0.tar.gz", hash = "sha256:116722e0a69549519cd97526bec54a33530d7c7059a21917b9c66073b2221fcb"},
 ]
 frozenlist = [
     {file = "frozenlist-1.3.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d2257aaba9660f78c7b1d8fea963b68f3feffb1a9d5d05a18401ca9eb3e8d0a3"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -75,17 +75,35 @@ unicode_backport = ["unicodedata2"]
 
 [[package]]
 name = "coredis"
-version = "2.3.1"
+version = "3.4.7"
 description = "Python async client for Redis key-value store"
 category = "main"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 
 [package.dependencies]
-hiredis = {version = ">=0.2.0", optional = true, markers = "extra == \"hiredis\""}
+deprecated = ">=1.2"
+hiredis = {version = ">=2.0.0", optional = true, markers = "extra == \"hiredis\""}
+packaging = ">=21,<22"
+typing-extensions = ">=4.2"
+wrapt = ">=1.1.0,<2"
 
 [package.extras]
-hiredis = ["hiredis (>=0.2.0)"]
+hiredis = ["hiredis (>=2.0.0)"]
+
+[[package]]
+name = "deprecated"
+version = "1.2.13"
+description = "Python @deprecated decorator to deprecate old python classes, functions or methods."
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[package.dependencies]
+wrapt = ">=1.10,<2"
+
+[package.extras]
+dev = ["tox", "bump2version (<1)", "sphinx (<2)", "importlib-metadata (<3)", "importlib-resources (<4)", "configparser (<5)", "sphinxcontrib-websupport (<2)", "zipp (<2)", "PyTest (<5)", "PyTest-Cov (<2.6)", "pytest", "pytest-cov"]
 
 [[package]]
 name = "dill"
@@ -149,6 +167,17 @@ optional = false
 python-versions = ">=3.7"
 
 [[package]]
+name = "packaging"
+version = "21.3"
+description = "Core utilities for Python packages"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyparsing = ">=2.0.2,<3.0.5 || >3.0.5"
+
+[[package]]
 name = "psutil"
 version = "5.9.0"
 description = "Cross-platform lib for process and system monitoring in Python."
@@ -182,6 +211,17 @@ six = "*"
 [package.extras]
 docs = ["sphinx (>=1.6.5)", "sphinx-rtd-theme"]
 tests = ["pytest (>=3.2.1,!=3.3.0)", "hypothesis (>=3.27.0)"]
+
+[[package]]
+name = "pyparsing"
+version = "3.0.8"
+description = "pyparsing module - Classes and methods to define and execute parsing grammars"
+category = "main"
+optional = false
+python-versions = ">=3.6.8"
+
+[package.extras]
+diagrams = ["railroad-diagrams", "jinja2"]
 
 [[package]]
 name = "python-dateutil"
@@ -237,6 +277,14 @@ python-versions = "*"
 widechars = ["wcwidth"]
 
 [[package]]
+name = "typing-extensions"
+version = "4.2.0"
+description = "Backported and Experimental Type Hints for Python 3.7+"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[[package]]
 name = "uvloop"
 version = "0.16.0"
 description = "Fast implementation of asyncio event loop on top of libuv"
@@ -248,6 +296,14 @@ python-versions = ">=3.7"
 dev = ["Cython (>=0.29.24,<0.30.0)", "pytest (>=3.6.0)", "Sphinx (>=4.1.2,<4.2.0)", "sphinxcontrib-asyncio (>=0.3.0,<0.4.0)", "sphinx-rtd-theme (>=0.5.2,<0.6.0)", "aiohttp", "flake8 (>=3.9.2,<3.10.0)", "psutil", "pycodestyle (>=2.7.0,<2.8.0)", "pyOpenSSL (>=19.0.0,<19.1.0)", "mypy (>=0.800)"]
 docs = ["Sphinx (>=4.1.2,<4.2.0)", "sphinxcontrib-asyncio (>=0.3.0,<0.4.0)", "sphinx-rtd-theme (>=0.5.2,<0.6.0)"]
 test = ["aiohttp", "flake8 (>=3.9.2,<3.10.0)", "psutil", "pycodestyle (>=2.7.0,<2.8.0)", "pyOpenSSL (>=19.0.0,<19.1.0)", "mypy (>=0.800)"]
+
+[[package]]
+name = "wrapt"
+version = "1.14.1"
+description = "Module for decorators, wrappers and monkey patching."
+category = "main"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 
 [[package]]
 name = "yarl"
@@ -264,7 +320,7 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.10"
-content-hash = "84f4da379d405391917737fe2e7234d29aadb01272df17ff6771222630c54b40"
+content-hash = "dca3fde5f9e4987f2dc9618df687e7264fd64845e55e711b2360c51f2fc16498"
 
 [metadata.files]
 aiohttp = [
@@ -410,7 +466,20 @@ charset-normalizer = [
     {file = "charset_normalizer-2.0.12-py3-none-any.whl", hash = "sha256:6881edbebdb17b39b4eaaa821b438bf6eddffb4468cf344f09f89def34a8b1df"},
 ]
 coredis = [
-    {file = "coredis-2.3.1.tar.gz", hash = "sha256:44c046a1d5bf176393f3b61ccb57dbd10174c8e4677b58fe59470fb09a4b7a1b"},
+    {file = "coredis-3.4.7-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9267a54e74b7498483f3f0a65e0a2918799edeaab8464c95d7e698660f7779fb"},
+    {file = "coredis-3.4.7-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d85998d78de1325e30375ee9196a76510bb6283b5abab523742796c460238d5a"},
+    {file = "coredis-3.4.7-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f568d730b08c8336b19c891e5ecf780b7a3634fffceba895674f35c1062d3f38"},
+    {file = "coredis-3.4.7-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:cb4eb881e4642778e437e258a8e3543e8fdd9cfb80a6b4084d2229fe5f3ece28"},
+    {file = "coredis-3.4.7-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d905460dbd733df0883b254e8edc7b10c8b517b820fe87bb36067a309bde95d8"},
+    {file = "coredis-3.4.7-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f1b3d221ebd819d555095344e4cc265580fa89a47ed7e1ecd2f6db00a612c31"},
+    {file = "coredis-3.4.7-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:6a995a8322eca8bfc537be4ffcfabe69a9fb8aaa9d2b6b1baa455d658a2d82c5"},
+    {file = "coredis-3.4.7-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bd091f8d12b0870148cf8e119e3778ce95b5826977c64f67f41db7e64c2c1bc4"},
+    {file = "coredis-3.4.7-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1ef547c5f64cf4abde5e094170571fe49dfb111ec15026e88e1e999a0b803051"},
+    {file = "coredis-3.4.7.tar.gz", hash = "sha256:a165b83a38511570f4c3a9f1cb32216196bcd0d48d5c1c74dc6715d96c08a8db"},
+]
+deprecated = [
+    {file = "Deprecated-1.2.13-py2.py3-none-any.whl", hash = "sha256:64756e3e14c8c5eea9795d93c524551432a0be75629f8f29e67ab8caf076c76d"},
+    {file = "Deprecated-1.2.13.tar.gz", hash = "sha256:43ac5335da90c31c24ba028af536a91d41d53f9e6901ddb021bcc572ce44e38d"},
 ]
 dill = [
     {file = "dill-0.3.4-py2.py3-none-any.whl", hash = "sha256:7e40e4a70304fd9ceab3535d36e58791d9c4a776b38ec7f7ec9afc8d3dca4d4f"},
@@ -589,6 +658,10 @@ multidict = [
     {file = "multidict-6.0.2-cp39-cp39-win_amd64.whl", hash = "sha256:4bae31803d708f6f15fd98be6a6ac0b6958fcf68fda3c77a048a4f9073704aae"},
     {file = "multidict-6.0.2.tar.gz", hash = "sha256:5ff3bd75f38e4c43f1f470f2df7a4d430b821c4ce22be384e1459cb57d6bb013"},
 ]
+packaging = [
+    {file = "packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},
+    {file = "packaging-21.3.tar.gz", hash = "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"},
+]
 psutil = [
     {file = "psutil-5.9.0-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:55ce319452e3d139e25d6c3f85a1acf12d1607ddedea5e35fb47a552c051161b"},
     {file = "psutil-5.9.0-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:7336292a13a80eb93c21f36bde4328aa748a04b68c13d01dfddd67fc13fd0618"},
@@ -647,6 +720,10 @@ pynacl = [
     {file = "PyNaCl-1.4.0-cp38-cp38-win_amd64.whl", hash = "sha256:7c6092102219f59ff29788860ccb021e80fffd953920c4a8653889c029b2d420"},
     {file = "PyNaCl-1.4.0.tar.gz", hash = "sha256:54e9a2c849c742006516ad56a88f5c74bf2ce92c9f67435187c3c5953b346505"},
 ]
+pyparsing = [
+    {file = "pyparsing-3.0.8-py3-none-any.whl", hash = "sha256:ef7b523f6356f763771559412c0d7134753f037822dad1b16945b7b846f7ad06"},
+    {file = "pyparsing-3.0.8.tar.gz", hash = "sha256:7bf433498c016c4314268d95df76c81b842a4cb2b276fa3312cfb1e1d85f6954"},
+]
 python-dateutil = [
     {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
     {file = "python_dateutil-2.8.2-py2.py3-none-any.whl", hash = "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"},
@@ -666,6 +743,10 @@ tabulate = [
     {file = "tabulate-0.8.9-py3-none-any.whl", hash = "sha256:d7c013fe7abbc5e491394e10fa845f8f32fe54f8dc60c6622c6cf482d25d47e4"},
     {file = "tabulate-0.8.9.tar.gz", hash = "sha256:eb1d13f25760052e8931f2ef80aaf6045a6cceb47514db8beab24cded16f13a7"},
 ]
+typing-extensions = [
+    {file = "typing_extensions-4.2.0-py3-none-any.whl", hash = "sha256:6657594ee297170d19f67d55c05852a874e7eb634f4f753dbd667855e07c1708"},
+    {file = "typing_extensions-4.2.0.tar.gz", hash = "sha256:f1c24655a0da0d1b67f07e17a5e6b2a105894e6824b92096378bb3668ef02376"},
+]
 uvloop = [
     {file = "uvloop-0.16.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:6224f1401025b748ffecb7a6e2652b17768f30b1a6a3f7b44660e5b5b690b12d"},
     {file = "uvloop-0.16.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:30ba9dcbd0965f5c812b7c2112a1ddf60cf904c1c160f398e7eed3a6b82dcd9c"},
@@ -683,6 +764,72 @@ uvloop = [
     {file = "uvloop-0.16.0-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:98d117332cc9e5ea8dfdc2b28b0a23f60370d02e1395f88f40d1effd2cb86c4f"},
     {file = "uvloop-0.16.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1e5f2e2ff51aefe6c19ee98af12b4ae61f5be456cd24396953244a30880ad861"},
     {file = "uvloop-0.16.0.tar.gz", hash = "sha256:f74bc20c7b67d1c27c72601c78cf95be99d5c2cdd4514502b4f3eb0933ff1228"},
+]
+wrapt = [
+    {file = "wrapt-1.14.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:1b376b3f4896e7930f1f772ac4b064ac12598d1c38d04907e696cc4d794b43d3"},
+    {file = "wrapt-1.14.1-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:903500616422a40a98a5a3c4ff4ed9d0066f3b4c951fa286018ecdf0750194ef"},
+    {file = "wrapt-1.14.1-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:5a9a0d155deafd9448baff28c08e150d9b24ff010e899311ddd63c45c2445e28"},
+    {file = "wrapt-1.14.1-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:ddaea91abf8b0d13443f6dac52e89051a5063c7d014710dcb4d4abb2ff811a59"},
+    {file = "wrapt-1.14.1-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:36f582d0c6bc99d5f39cd3ac2a9062e57f3cf606ade29a0a0d6b323462f4dd87"},
+    {file = "wrapt-1.14.1-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:7ef58fb89674095bfc57c4069e95d7a31cfdc0939e2a579882ac7d55aadfd2a1"},
+    {file = "wrapt-1.14.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:e2f83e18fe2f4c9e7db597e988f72712c0c3676d337d8b101f6758107c42425b"},
+    {file = "wrapt-1.14.1-cp27-cp27mu-manylinux2010_i686.whl", hash = "sha256:ee2b1b1769f6707a8a445162ea16dddf74285c3964f605877a20e38545c3c462"},
+    {file = "wrapt-1.14.1-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:833b58d5d0b7e5b9832869f039203389ac7cbf01765639c7309fd50ef619e0b1"},
+    {file = "wrapt-1.14.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:80bb5c256f1415f747011dc3604b59bc1f91c6e7150bd7db03b19170ee06b320"},
+    {file = "wrapt-1.14.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:07f7a7d0f388028b2df1d916e94bbb40624c59b48ecc6cbc232546706fac74c2"},
+    {file = "wrapt-1.14.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:02b41b633c6261feff8ddd8d11c711df6842aba629fdd3da10249a53211a72c4"},
+    {file = "wrapt-1.14.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2fe803deacd09a233e4762a1adcea5db5d31e6be577a43352936179d14d90069"},
+    {file = "wrapt-1.14.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:257fd78c513e0fb5cdbe058c27a0624c9884e735bbd131935fd49e9fe719d310"},
+    {file = "wrapt-1.14.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:4fcc4649dc762cddacd193e6b55bc02edca674067f5f98166d7713b193932b7f"},
+    {file = "wrapt-1.14.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:11871514607b15cfeb87c547a49bca19fde402f32e2b1c24a632506c0a756656"},
+    {file = "wrapt-1.14.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:8ad85f7f4e20964db4daadcab70b47ab05c7c1cf2a7c1e51087bfaa83831854c"},
+    {file = "wrapt-1.14.1-cp310-cp310-win32.whl", hash = "sha256:a9a52172be0b5aae932bef82a79ec0a0ce87288c7d132946d645eba03f0ad8a8"},
+    {file = "wrapt-1.14.1-cp310-cp310-win_amd64.whl", hash = "sha256:6d323e1554b3d22cfc03cd3243b5bb815a51f5249fdcbb86fda4bf62bab9e164"},
+    {file = "wrapt-1.14.1-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:43ca3bbbe97af00f49efb06e352eae40434ca9d915906f77def219b88e85d907"},
+    {file = "wrapt-1.14.1-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:6b1a564e6cb69922c7fe3a678b9f9a3c54e72b469875aa8018f18b4d1dd1adf3"},
+    {file = "wrapt-1.14.1-cp35-cp35m-manylinux2010_i686.whl", hash = "sha256:00b6d4ea20a906c0ca56d84f93065b398ab74b927a7a3dbd470f6fc503f95dc3"},
+    {file = "wrapt-1.14.1-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:a85d2b46be66a71bedde836d9e41859879cc54a2a04fad1191eb50c2066f6e9d"},
+    {file = "wrapt-1.14.1-cp35-cp35m-win32.whl", hash = "sha256:dbcda74c67263139358f4d188ae5faae95c30929281bc6866d00573783c422b7"},
+    {file = "wrapt-1.14.1-cp35-cp35m-win_amd64.whl", hash = "sha256:b21bb4c09ffabfa0e85e3a6b623e19b80e7acd709b9f91452b8297ace2a8ab00"},
+    {file = "wrapt-1.14.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:9e0fd32e0148dd5dea6af5fee42beb949098564cc23211a88d799e434255a1f4"},
+    {file = "wrapt-1.14.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9736af4641846491aedb3c3f56b9bc5568d92b0692303b5a305301a95dfd38b1"},
+    {file = "wrapt-1.14.1-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5b02d65b9ccf0ef6c34cba6cf5bf2aab1bb2f49c6090bafeecc9cd81ad4ea1c1"},
+    {file = "wrapt-1.14.1-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:21ac0156c4b089b330b7666db40feee30a5d52634cc4560e1905d6529a3897ff"},
+    {file = "wrapt-1.14.1-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:9f3e6f9e05148ff90002b884fbc2a86bd303ae847e472f44ecc06c2cd2fcdb2d"},
+    {file = "wrapt-1.14.1-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:6e743de5e9c3d1b7185870f480587b75b1cb604832e380d64f9504a0535912d1"},
+    {file = "wrapt-1.14.1-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:d79d7d5dc8a32b7093e81e97dad755127ff77bcc899e845f41bf71747af0c569"},
+    {file = "wrapt-1.14.1-cp36-cp36m-win32.whl", hash = "sha256:81b19725065dcb43df02b37e03278c011a09e49757287dca60c5aecdd5a0b8ed"},
+    {file = "wrapt-1.14.1-cp36-cp36m-win_amd64.whl", hash = "sha256:b014c23646a467558be7da3d6b9fa409b2c567d2110599b7cf9a0c5992b3b471"},
+    {file = "wrapt-1.14.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:88bd7b6bd70a5b6803c1abf6bca012f7ed963e58c68d76ee20b9d751c74a3248"},
+    {file = "wrapt-1.14.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b5901a312f4d14c59918c221323068fad0540e34324925c8475263841dbdfe68"},
+    {file = "wrapt-1.14.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d77c85fedff92cf788face9bfa3ebaa364448ebb1d765302e9af11bf449ca36d"},
+    {file = "wrapt-1.14.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8d649d616e5c6a678b26d15ece345354f7c2286acd6db868e65fcc5ff7c24a77"},
+    {file = "wrapt-1.14.1-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:7d2872609603cb35ca513d7404a94d6d608fc13211563571117046c9d2bcc3d7"},
+    {file = "wrapt-1.14.1-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:ee6acae74a2b91865910eef5e7de37dc6895ad96fa23603d1d27ea69df545015"},
+    {file = "wrapt-1.14.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:2b39d38039a1fdad98c87279b48bc5dce2c0ca0d73483b12cb72aa9609278e8a"},
+    {file = "wrapt-1.14.1-cp37-cp37m-win32.whl", hash = "sha256:60db23fa423575eeb65ea430cee741acb7c26a1365d103f7b0f6ec412b893853"},
+    {file = "wrapt-1.14.1-cp37-cp37m-win_amd64.whl", hash = "sha256:709fe01086a55cf79d20f741f39325018f4df051ef39fe921b1ebe780a66184c"},
+    {file = "wrapt-1.14.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:8c0ce1e99116d5ab21355d8ebe53d9460366704ea38ae4d9f6933188f327b456"},
+    {file = "wrapt-1.14.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:e3fb1677c720409d5f671e39bac6c9e0e422584e5f518bfd50aa4cbbea02433f"},
+    {file = "wrapt-1.14.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:642c2e7a804fcf18c222e1060df25fc210b9c58db7c91416fb055897fc27e8cc"},
+    {file = "wrapt-1.14.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7b7c050ae976e286906dd3f26009e117eb000fb2cf3533398c5ad9ccc86867b1"},
+    {file = "wrapt-1.14.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ef3f72c9666bba2bab70d2a8b79f2c6d2c1a42a7f7e2b0ec83bb2f9e383950af"},
+    {file = "wrapt-1.14.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:01c205616a89d09827986bc4e859bcabd64f5a0662a7fe95e0d359424e0e071b"},
+    {file = "wrapt-1.14.1-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:5a0f54ce2c092aaf439813735584b9537cad479575a09892b8352fea5e988dc0"},
+    {file = "wrapt-1.14.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:2cf71233a0ed05ccdabe209c606fe0bac7379fdcf687f39b944420d2a09fdb57"},
+    {file = "wrapt-1.14.1-cp38-cp38-win32.whl", hash = "sha256:aa31fdcc33fef9eb2552cbcbfee7773d5a6792c137b359e82879c101e98584c5"},
+    {file = "wrapt-1.14.1-cp38-cp38-win_amd64.whl", hash = "sha256:d1967f46ea8f2db647c786e78d8cc7e4313dbd1b0aca360592d8027b8508e24d"},
+    {file = "wrapt-1.14.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:3232822c7d98d23895ccc443bbdf57c7412c5a65996c30442ebe6ed3df335383"},
+    {file = "wrapt-1.14.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:988635d122aaf2bdcef9e795435662bcd65b02f4f4c1ae37fbee7401c440b3a7"},
+    {file = "wrapt-1.14.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9cca3c2cdadb362116235fdbd411735de4328c61425b0aa9f872fd76d02c4e86"},
+    {file = "wrapt-1.14.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d52a25136894c63de15a35bc0bdc5adb4b0e173b9c0d07a2be9d3ca64a332735"},
+    {file = "wrapt-1.14.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:40e7bc81c9e2b2734ea4bc1aceb8a8f0ceaac7c5299bc5d69e37c44d9081d43b"},
+    {file = "wrapt-1.14.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:b9b7a708dd92306328117d8c4b62e2194d00c365f18eff11a9b53c6f923b01e3"},
+    {file = "wrapt-1.14.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:6a9a25751acb379b466ff6be78a315e2b439d4c94c1e99cb7266d40a537995d3"},
+    {file = "wrapt-1.14.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:34aa51c45f28ba7f12accd624225e2b1e5a3a45206aa191f6f9aac931d9d56fe"},
+    {file = "wrapt-1.14.1-cp39-cp39-win32.whl", hash = "sha256:dee0ce50c6a2dd9056c20db781e9c1cfd33e77d2d569f5d1d9321c641bb903d5"},
+    {file = "wrapt-1.14.1-cp39-cp39-win_amd64.whl", hash = "sha256:dee60e1de1898bde3b238f18340eec6148986da0455d8ba7848d50470a7a32fb"},
+    {file = "wrapt-1.14.1.tar.gz", hash = "sha256:380a85cf89e0e69b7cfbe2ea9f765f004ff419f34194018a6827ac0e3edfed4d"},
 ]
 yarl = [
     {file = "yarl-1.7.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:f2a8508f7350512434e41065684076f640ecce176d262a7d54f0da41d99c5a95"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ strictyaml = "^1.6.1"
 tabulate = "^0.8.9"
 psutil = "^5.9.0"
 disnake = {extras = ["voice"], version = "^2.5.0"}
-coredis = {extras = ["hiredis"], version = "^2.3.1"}
+coredis = {extras = ["hiredis"], version = "^3.4.7"}
 
 [tool.poetry.dev-dependencies]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "Heleus"
 version = "2.0.0"
 description = "A Discord bot forked from Liara. Built on disnake."
-authors = ["derpychap <holla@derpychap.co.uk>"]
+authors = ["derpychap <derpy@duck.com>"]
 license = "MIT"
 
 [tool.poetry.dependencies]
@@ -13,7 +13,7 @@ raven = "^6.10.0"
 strictyaml = "^1.6.1"
 tabulate = "^0.8.9"
 psutil = "^5.9.0"
-disnake = {extras = ["voice"], version = "^2.4.0"}
+disnake = {extras = ["voice"], version = "^2.5.0"}
 coredis = {extras = ["hiredis"], version = "^2.3.1"}
 
 [tool.poetry.dev-dependencies]

--- a/utils/storage.py
+++ b/utils/storage.py
@@ -29,7 +29,7 @@ class RedisCollection:
 
     async def set(self, key, value):
         """Sets a key in the collection."""
-        await self.redis.hset(self.key, dill.dumps(key), dill.dumps(value))
+        await self.redis.hset(self.key, {dill.dumps(key): dill.dumps(value)})
 
     async def delete(self, key):
         """Removes a key. Does nothing if the key doesn't exist."""


### PR DESCRIPTION
This updates disnake to the latest stable version, which adds support for Discord's Command Permissions V2 and other features. 

Some VSCode config files have been added, which add some debug launch options and enforces the blue formatter.

The `HELEUS_LOADER` environment variable has been added, which allows users to override the default core cog with their own custom cog.